### PR TITLE
remove pyrogram copyright

### DIFF
--- a/tgram/sync.py
+++ b/tgram/sync.py
@@ -1,21 +1,3 @@
-#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
-#  Copyright (C) 2024 Zaid <https://github.com/2ei>
-#
-#  This file is part of Pyrogram.
-#
-#  Pyrogram is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU Lesser General Public License as published
-#  by the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  Pyrogram is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU Lesser General Public License for more details.
-#
-#  You should have received a copy of the GNU Lesser General Public License
-#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
-
 import asyncio
 import functools
 import inspect


### PR DESCRIPTION
well, you take this sync wrapper from pyrogram, but i don't think it's made by Dan.

[pytgcalls](https://github.com/pytgcalls/pytgcalls/blob/master/pytgcalls/sync.py) also used it, without mentioning Dan's copyright.