### PR TITLE
improve filters

### DIFF
--- a/tgram/filters.py
+++ b/tgram/filters.py
@@ -224,7 +224,7 @@ def regex(pattern: Union[str, Pattern], flags: int = 0):
     return Filter(regex_filter)
 
 
-def chat_type_filter(types: Union[list, str]) -> Filter:
+def chat_type(types: Union[list, str]) -> Filter:
     """Filter updates that match a given chat type."""
     types = (
         {types.lower()} if not isinstance(types, list) else {i.lower() for i in types}
@@ -247,9 +247,8 @@ def chat_type_filter(types: Union[list, str]) -> Filter:
     return Filter(chat_filter)
 
 
-private = chat_type_filter("private")
-group = chat_type_filter(["group", "supergroup"])
-channel = chat_type_filter("channel")
+private = chat_type("private")
+group = chat_type(["group", "supergroup"])
 
 
 def command(


### PR DESCRIPTION
1 - remove `channel` filter ( bot's do not get message updates from channels ), there is` Update.channel_post` and `Update.edited_channel_post` so we have just to use `TgBot.on_channel_post` decorator.

2 - rename `chat_type_filter` to `chat_type` so we can use it as
```python
filters.chat_type("group")

# or filters.chat_type(["supergroup", "private"])
```